### PR TITLE
Unprefixed name slot handling (+null-check).

### DIFF
--- a/domino_generator/example/ex3/web-project/components/named-div/colorbox.g.dart
+++ b/domino_generator/example/ex3/web-project/components/named-div/colorbox.g.dart
@@ -17,7 +17,9 @@ void renderBlueBox(
 
   $d.open('div');
   $d.text('\n        BB\n        ');
-  slot($d);
+  if (slot != null) {
+    slot($d);
+  }
   $d.text('\n        LO\n    ');
   $d.close();
 }

--- a/domino_generator/lib/src/canonical.dart
+++ b/domino_generator/lib/src/canonical.dart
@@ -116,7 +116,7 @@ ParsedSource parseToCanonical(String html,
 List<String> _collectSlots(Element elem) {
   final slotNames = <String>[];
   if (elem.localName == 'd-slot') {
-    final name = dartName(elem.attributes['*'] ?? '', prefix: 'slot');
+    final name = dartName(elem.attributes['*'] ?? 'slot');
     elem.attributes['*'] = name;
     slotNames.add(name);
   }

--- a/domino_generator/lib/src/component_generator.dart
+++ b/domino_generator/lib/src/component_generator.dart
@@ -309,7 +309,7 @@ class ComponentGenerator {
 
   void _renderSlot(Stack stack, Element elem) {
     final method = elem.attributes.remove('*');
-    _sb.writeln('$method(\$d);');
+    _sb.writeln('if ($method != null) {$method(\$d);}');
   }
 
   void _renderStyle(Stack stack, Element elem) {


### PR DESCRIPTION
This change ensures that the name in `d-slot-call` and `d-slot` is the same. Dropping the `slot` prefix for simplicity.